### PR TITLE
Re-encode for my csv problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ If you have a column with a name such as `_commit_` it will be renamed too, addi
 - `--namespace TEXT` - use this if you wish to include the history of multiple different files in the same database. The default is `item` but you can set it to something else, which will produce tables with names like `yournamespace` and `yournamespace_version`.
 - `--wal` - Enable WAL mode on the created database file. Use this if you plan to run queries against the database while `git-history` is creating it.
 - `--silent` - don't show the progress bar.
+- `--re-encode TEXT` - re-encode the incoming data from this character encoding (e.g. `--re-encode=iso-8859-1` to convert from `Latin-1`); you can use `file -I filename` to get the encoding on some distributions.
 
 ### CSV and TSV data
 

--- a/git_history/cli.py
+++ b/git_history/cli.py
@@ -122,6 +122,11 @@ def cli():
     is_flag=True,
     help="Don't show progress bar",
 )
+@click.option(
+    "--re-encode",
+    type=str,
+    help="Re-encodes incoming data from this charset (e.g. --re-encode=iso-8859-1)",
+)
 @click.version_option()
 def file(
     database,
@@ -143,6 +148,7 @@ def file(
     wal,
     debug,
     silent,
+    re_encode,
 ):
     "Analyze the history of a specific file and write it to SQLite"
     if csv_ and convert:
@@ -231,7 +237,10 @@ def file(
 
             # list() to resolve generators for repeated access later
             try:
-                items = list(convert_function(content))
+                if re_encode:
+                    items = list(convert_function(content.decode(re_encode).encode("utf-8")))
+                else:
+                    items = list(convert_function(content))
             except Exception:
                 print("\nError in commit: {}".format(git_hash))
                 raise

--- a/git_history/cli.py
+++ b/git_history/cli.py
@@ -27,7 +27,7 @@ def iterate_file_versions(
         if progress_bar:
             progress_bar.update(1)
         try:
-            blob = [b for b in commit.tree.blobs if b.name == relative_path][0]
+            blob = commit.tree[relative_path]
             yield commit.committed_datetime, commit.hexsha, blob.data_stream.read()
         except IndexError:
             # This commit doesn't have a copy of the requested file


### PR DESCRIPTION
Discussed in https://github.com/simonw/git-history/discussions/50

I think I had two problems here, but they might be related:

1. `commit.tree.blobs` was `[]` here. I changed this to use the `tree['filename']` [notation](https://gitpython.readthedocs.io/en/stable/reference.html#git.objects.tree.Tree)
2. my data was in Latin-1/iso-8859-1 (I didn't know this at first). I added an option to `--re-encode`

Tests pass.