### PR TITLE
Allow the database file to live in a nested subdirectory

### DIFF
--- a/git_history/cli.py
+++ b/git_history/cli.py
@@ -27,9 +27,9 @@ def iterate_file_versions(
         if progress_bar:
             progress_bar.update(1)
         try:
-            blob = [b for b in commit.tree.blobs if b.name == relative_path][0]
+            blob = commit.tree[relative_path]
             yield commit.committed_datetime, commit.hexsha, blob.data_stream.read()
-        except IndexError:
+        except KeyError:
             # This commit doesn't have a copy of the requested file
             pass
 


### PR DESCRIPTION
I was running essentially `git-history file data/pipelines.db data/pipelines.json` and getting empty databases. Iterating over `commit.tree.blobs` only looks for files in the top level directory. Since my data was nested, I needed to iterate over `commit.tree.trees` also. According to some experimentation and the python-git docs, this path-like syntax should work for deeply nested files.