### PR TITLE
Item should link to commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ CREATE UNIQUE INDEX [idx_commits_namespace_hash]
 CREATE TABLE [item] (
    [IncidentID] TEXT,
    [Location] TEXT,
-   [Type] TEXT
+   [Type] TEXT,
+   [_commit] INTEGER REFERENCES [commits]([id])
 );
 ```
 <!-- [[[end]]] -->

--- a/git_history/cli.py
+++ b/git_history/cli.py
@@ -241,9 +241,14 @@ def file(
 
             if not ids:
                 # no --id - so just populate item_table and add item["_commit"]
-                for item in items:
-                    item = jsonify_all(fix_reserved_columns(item))
-                    item["_commit"] = commit_pk
+                items = [
+                    {
+                        **jsonify_all(fix_reserved_columns(item)),
+                        "_commit": commit_pk,
+                    }
+
+                    for item in items
+                ]
                 db[item_table].insert_all(
                     items,
                     column_order=("_id",),

--- a/tests/test_git_history.py
+++ b/tests/test_git_history.py
@@ -224,17 +224,18 @@ def test_file_without_id(repo, tmpdir, namespace):
         "    ON [commits] ([namespace], [hash]);\n"
         "CREATE TABLE [{}] (\n".format(namespace or "item")
         + "   [product_id] INTEGER,\n"
-        "   [name] TEXT\n"
+        "   [name] TEXT,\n"
+        "   [_commit] INTEGER REFERENCES [commits]([id])\n"
         ");"
     )
     assert db["commits"].count == 2
     # Should have some duplicates
-    assert [(r["product_id"], r["name"]) for r in db[namespace or "item"].rows] == [
-        (1, "Gin"),
-        (2, "Tonic"),
-        (1, "Gin"),
-        (2, "Tonic 2"),
-        (3, "Rum"),
+    assert [(r["product_id"], r["name"], r["_commit"]) for r in db[namespace or "item"].rows] == [
+        (1, "Gin", 1),
+        (2, "Tonic", 1),
+        (1, "Gin", 2),
+        (2, "Tonic 2", 2),
+        (3, "Rum", 2),
     ]
 
 


### PR DESCRIPTION
There's a bug in the non-id branch. Each `item` in `items` is redefined, with a new object, then `_commit` is set, but never used anywhere.

In my use case, I need to know the commit each item comes from, and this fix allows it:
<img width="710" alt="image" src="https://user-images.githubusercontent.com/167319/197303713-db3196c5-2b5e-444a-ad79-d0882d34b5ac.png">